### PR TITLE
Support writev_at for File

### DIFF
--- a/monoio/src/driver/op/write.rs
+++ b/monoio/src/driver/op/write.rs
@@ -216,12 +216,30 @@ pub(crate) struct WriteVecAt<T> {
     buf_vec: T,
 }
 
+impl<T: IoVecBuf> Op<WriteVecAt<T>> {
+    pub(crate) fn writev_at(fd: SharedFd, buf_vec: T, offset: u64) -> io::Result<Self> {
+        Op::submit_with(WriteVecAt {
+            fd,
+            buf_vec,
+            offset,
+        })
+    }
+
+    pub(crate) fn writev_at_raw(fd: &SharedFd, buf_vec: T, offset: u64) -> WriteVecAt<T> {
+        WriteVecAt {
+            fd: fd.clone(),
+            buf_vec,
+            offset,
+        }
+    }
+}
+
 #[cfg(not(windows))]
 impl<T: IoVecBuf> OpAble for WriteVecAt<T> {
     #[cfg(all(target_os = "linux", feature = "iouring"))]
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
         opcode::Writev::new(
-            types::Fd(libc::AT_FDCWD),
+            types::Fd(self.fd.raw_fd()),
             self.buf_vec.read_iovec_ptr(),
             self.buf_vec.read_iovec_len() as _,
         )

--- a/monoio/src/fs/file/mod.rs
+++ b/monoio/src/fs/file/mod.rs
@@ -299,6 +299,49 @@ impl File {
         file_impl::write_vectored(self.fd.clone(), buf_vec).await
     }
 
+    /// This function attempts to write the entire contents of `buf_vec`, but the write may not
+    /// fully succeed, and it might also result in an error. The bytes will be written starting at
+    /// the specified offset.
+    ///
+    /// # Return
+    ///
+    /// The method returns the result of the operation along with the same array of buffers passed
+    /// as an argument. A return value of `0` typically indicates that the underlying file can no
+    /// longer accept bytes and likely won't be able to in the future, or that the provided buffer
+    /// is empty.
+    ///
+    /// # Errors
+    ///
+    /// Each `write` call may result in an I/O error, indicating the operation couldn't be
+    /// completed. If an error occurs, no bytes from the buffer were written to the file.
+    ///
+    /// It is **not** considered an error if the entire buffer could not be written to the file.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use monoio::io::AsyncWriteRent;
+    ///
+    /// #[monoio::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     let buf_vec = monoio::buf::VecBuf::from(vec![
+    ///         "Hello".to_owned().into_bytes(),
+    ///         "World".to_owned().into_bytes(),
+    ///     ]);
+    ///     let mut file = monoio::fs::File::create("example.txt").await?;
+    ///     let (res, buf_vec) = file.write_vectored_at(buf_vec, 0).await;
+    ///     res?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn write_vectored_at<T: IoVecBuf>(
+        &self,
+        buf_vec: T,
+        offset: u64,
+    ) -> crate::BufResult<usize, T> {
+        file_impl::write_vectored_at(self.fd.clone(), buf_vec, offset).await
+    }
+
     /// Write a buffer into this file at the specified offset, returning how
     /// many bytes were written.
     ///
@@ -428,6 +471,41 @@ impl File {
         }
 
         (Ok(()), buf)
+    }
+
+    /// Write all at a specified offset
+    pub async fn write_vectored_all_at<T: IoVecBuf>(
+        &mut self,
+        buf: T,
+        pos: usize,
+    ) -> crate::BufResult<usize, T> {
+        let mut meta = crate::buf::read_vec_meta(&buf);
+        let len = meta.len();
+        let mut written = 0;
+
+        while written < len {
+            let (res, meta_) = self.writev_at(meta, pos + written).await;
+            println!("res {:?}", res);
+            meta = meta_;
+            match res {
+                Ok(0) => {
+                    return (
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::WriteZero,
+                            "failed to write whole buffer",
+                        )),
+                        buf,
+                    )
+                }
+                Ok(n) => {
+                    written += n;
+                    meta.consume(n);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return (Err(e), buf),
+            }
+        }
+        (Ok(written), buf)
     }
 
     /// Attempts to sync all OS-internal metadata to disk.
@@ -646,6 +724,14 @@ impl AsyncWriteRentAt for File {
         pos: usize,
     ) -> impl Future<Output = BufResult<usize, T>> {
         File::write_at(self, buf, pos as u64)
+    }
+
+    fn writev_at<T: IoVecBuf>(
+        &mut self,
+        buf: T,
+        pos: usize,
+    ) -> impl Future<Output = BufResult<usize, T>> {
+        File::write_vectored_at(self, buf, pos as u64)
     }
 }
 

--- a/monoio/src/fs/file/unix.rs
+++ b/monoio/src/fs/file/unix.rs
@@ -81,6 +81,7 @@ mod iouring {
     uring_op!(write<IoBuf>(write, buf));
     uring_op!(write_at<IoBuf>(write_at, buf, pos: u64));
     uring_op!(write_vectored<IoVecBuf>(writev, buf_vec));
+    uring_op!(write_vectored_at<IoVecBuf>(writev_at, buf_vec, pos: u64));
 }
 
 #[cfg(all(not(feature = "iouring"), feature = "sync"))]

--- a/monoio/src/io/async_write_rent.rs
+++ b/monoio/src/io/async_write_rent.rs
@@ -84,6 +84,29 @@ pub trait AsyncWriteRentAt {
         buf: T,
         pos: usize,
     ) -> impl Future<Output = BufResult<usize, T>>;
+
+    /// This function attempts to write the entire contents of `buf_vec`, but the write may not
+    /// fully succeed, and it might also result in an error. The bytes will be written starting at
+    /// the specified offset.
+    ///
+    /// # Return
+    ///
+    /// The method returns the result of the operation along with the same array of buffers passed
+    /// as an argument. A return value of `0` typically indicates that the underlying file can no
+    /// longer accept bytes and likely won't be able to in the future, or that the provided buffer
+    /// is empty.
+    ///
+    /// # Errors
+    ///
+    /// Each `write` call may result in an I/O error, indicating the operation couldn't be
+    /// completed. If an error occurs, no bytes from the buffer were written to the writer.
+    ///
+    /// It is **not** considered an error if the entire buffer could not be written to this writer.
+    fn writev_at<T: IoVecBuf>(
+        &mut self,
+        buf: T,
+        pos: usize,
+    ) -> impl Future<Output = BufResult<usize, T>>;
 }
 
 impl<A: ?Sized + AsyncWriteRentAt> AsyncWriteRentAt for &mut A {
@@ -94,6 +117,14 @@ impl<A: ?Sized + AsyncWriteRentAt> AsyncWriteRentAt for &mut A {
         pos: usize,
     ) -> impl Future<Output = BufResult<usize, T>> {
         (**self).write_at(buf, pos)
+    }
+
+    fn writev_at<T: IoVecBuf>(
+        &mut self,
+        buf: T,
+        pos: usize,
+    ) -> impl Future<Output = BufResult<usize, T>> {
+        (**self).writev_at(buf, pos)
     }
 }
 

--- a/monoio/tests/fs_file.rs
+++ b/monoio/tests/fs_file.rs
@@ -4,6 +4,7 @@ use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle as RawFd};
 
+use monoio::io::AsyncWriteRentAt;
 use monoio::{
     buf::VecBuf,
     fs::File,
@@ -12,6 +13,7 @@ use monoio::{
 use tempfile::NamedTempFile;
 
 const HELLO: &[u8] = b"hello world...";
+const GOODBYE: &[u8] = b"goodbye world!";
 
 async fn read_hello(file: &File, offset: u64) {
     let buf = Vec::with_capacity(1024);
@@ -140,6 +142,35 @@ async fn basic_write_vectored() {
     assert!(matches!(res, Ok(len) if len == HELLO.len() * 2));
     let result = monoio::fs::read(tempfile.path()).await.unwrap();
     assert_eq!(result, [HELLO, HELLO, HELLO, HELLO].concat());
+}
+
+#[monoio::test_all]
+async fn basic_write_vectored_at() {
+    let tempfile = tempfile();
+    let mut file = File::create(tempfile.path()).await.unwrap();
+    // Test assumes HELLO and GOODBYE are of the same length.
+    assert_eq!(HELLO.len(), GOODBYE.len());
+
+    let (res, _) = file
+        .write_vectored_all_at(VecBuf::from(vec![HELLO.to_vec(); 2]), 0)
+        .await;
+    assert_eq!(res.unwrap(), HELLO.len() * 2);
+    let result = monoio::fs::read(tempfile.path()).await.unwrap();
+    assert_eq!(result, [HELLO, HELLO].concat());
+
+    let (res, _) = file
+        .write_vectored_all_at(VecBuf::from(vec![HELLO.to_vec(); 2]), HELLO.len() * 2)
+        .await;
+    assert!(matches!(res, Ok(len) if len == HELLO.len() * 2));
+    let result = monoio::fs::read(tempfile.path()).await.unwrap();
+    assert_eq!(result, [HELLO, HELLO, HELLO, HELLO].concat());
+
+    let (res, _) = file
+        .writev_at(VecBuf::from(vec![GOODBYE.to_vec(); 2]), HELLO.len() * 1)
+        .await;
+    assert!(matches!(res, Ok(len) if len == GOODBYE.len() * 2));
+    let result = monoio::fs::read(tempfile.path()).await.unwrap();
+    assert_eq!(result, [HELLO, GOODBYE, GOODBYE, HELLO].concat());
 }
 
 #[monoio::test_all]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for vectored writes at a specific file offset, enabling writing multiple buffers without changing the file cursor.
  - Introduced a “write all” variant that ensures all provided buffers are written at the given offset, handling partial writes transparently.
  - Extended async writer capabilities to perform vectored writes at a specified position.

- Tests
  - Added coverage for offset-based vectored writes, validating correct ordering and content across multiple write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->